### PR TITLE
fix: retry KN import without deprecated indexes

### DIFF
--- a/samples/supply_ontology_hand/tools/import_kn.py
+++ b/samples/supply_ontology_hand/tools/import_kn.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import subprocess
 import sys
@@ -34,6 +35,17 @@ def resolve_default_embedding() -> str:
     return str(model_id)
 
 
+def strip_index_config(node) -> None:
+    """Recursively remove deprecated property index settings in place."""
+    if isinstance(node, dict):
+        node.pop("index_config", None)
+        for value in node.values():
+            strip_index_config(value)
+    elif isinstance(node, list):
+        for item in node:
+            strip_index_config(item)
+
+
 def import_kn(
     json_path: Path, *, dry_run: bool = False, resolve_embedding: bool = False
 ) -> dict:
@@ -62,8 +74,20 @@ def import_kn(
         report["action"] = "would_import"
         return report
 
-    body = json.dumps(payload, ensure_ascii=False)
-    raw = run_cmd(["openbkn", "--json", "call", "-X", "POST", _IMPORT_PATH, "-d", body])
+    def post(body_payload: dict) -> str:
+        body = json.dumps(body_payload, ensure_ascii=False)
+        return run_cmd(["openbkn", "--json", "call", "-X", "POST", _IMPORT_PATH, "-d", body])
+
+    try:
+        raw = post(payload)
+        report["index_config_stripped"] = False
+    except RuntimeError as exc:
+        if "index_config" not in str(exc):
+            raise
+        stripped = copy.deepcopy(payload)
+        strip_index_config(stripped)
+        raw = post(stripped)
+        report["index_config_stripped"] = True
     try:
         report["import_response"] = json.loads(raw)
     except json.JSONDecodeError:

--- a/samples/supply_ontology_hand/tools/tests/test_import_kn.py
+++ b/samples/supply_ontology_hand/tools/tests/test_import_kn.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import import_kn as import_kn_module
 from import_kn import import_kn
 
 KN = Path(__file__).resolve().parents[2] / "kn" / "supply_ontology_hand.json"
@@ -23,3 +24,43 @@ def test_kn_json_has_required_fields():
     assert len(payload["id"]) <= 32
     assert isinstance(payload.get("object_types"), list)
     assert len(payload["object_types"]) > 0
+
+
+def test_import_retries_without_index_config_when_platform_rejects_it(tmp_path, monkeypatch):
+    payload = {
+        "id": "test_network",
+        "name": "Test network",
+        "object_types": [
+            {
+                "data_properties": [
+                    {
+                        "name": "material_name",
+                        "index_config": {"vector_config": {"enabled": True}},
+                    },
+                ],
+            },
+        ],
+    }
+    json_path = tmp_path / "kn.json"
+    json_path.write_text(json.dumps(payload), encoding="utf-8")
+    posted_bodies = []
+
+    def fake_run_cmd(args):
+        if args[2] == "call":
+            posted_bodies.append(json.loads(args[-1]))
+            if len(posted_bodies) == 1:
+                raise RuntimeError("数据属性 material_name 不再支持 index_config")
+            return json.dumps({"ok": True})
+        if args[2:4] == ["bkn", "get"]:
+            return json.dumps({"id": "test_network", "name": "Test network"})
+        raise AssertionError(args)
+
+    monkeypatch.setattr(import_kn_module, "run_cmd", fake_run_cmd)
+
+    report = import_kn_module.import_kn(json_path)
+
+    assert report["index_config_stripped"] is True
+    assert len(posted_bodies) == 2
+    assert "index_config" in posted_bodies[0]["object_types"][0]["data_properties"][0]
+    assert "index_config" not in posted_bodies[1]["object_types"][0]["data_properties"][0]
+    assert "index_config" in json.loads(json_path.read_text(encoding="utf-8"))["object_types"][0]["data_properties"][0]


### PR DESCRIPTION
## Summary
- retain --resolve-embedding support during KN import
- retry once without deprecated property-level index_config when newer platforms reject it
- add regression coverage for the compatibility retry

## Test plan
- python3 -m pytest tests -q (306 passed)