### PR TITLE
fix(samples): align CLI usage with SDK

### DIFF
--- a/samples/supply_ontology_hand/docs/manual-operation-guide.md
+++ b/samples/supply_ontology_hand/docs/manual-operation-guide.md
@@ -47,7 +47,7 @@ python3 verify_sample.py
 python3 register_skills.py
 python3 register_skills.py --apply
 python3 setup_skill_dataset.py --interactive --apply --kn-id supply_ontology_hand
-openbkn --json vega catalog discover <catalog-id-from-config.yaml> --wait
+python3 setup_catalog.py --config config.yaml --write-config
 python3 bind_skill_dataset.py --kn-id supply_ontology_hand --catalog-id <catalog-id-from-config.yaml> --apply
 python3 power_layer.py --dry-run all --kn-id supply_ontology_hand
 python3 power_layer.py all --kn-id supply_ontology_hand

--- a/samples/supply_ontology_hand/docs/openbkn-hand-import-guide_cn.md
+++ b/samples/supply_ontology_hand/docs/openbkn-hand-import-guide_cn.md
@@ -367,7 +367,7 @@ python3 setup_catalog.py --config config.yaml --write-config
 
 1. 按 `database` + `vega.catalog_host` 组装连接器配置  
 2. 若 `catalog_id` 为空：按 `catalog_name` 查找已有 Catalog，否则 `vega catalog create`  
-3. `vega catalog enable` → `test-connection` → `discover --wait`  
+3. `vega catalog enable` → `test-connection` → 触发异步 `discover` 并轮询任务终态
 4. 校验 Catalog 中可见附录 A 的 **12 张表**  
 5. `--write-config` 时将 `catalog_id` 写回 `config.yaml`
 
@@ -379,7 +379,8 @@ python3 setup_catalog.py --config config.yaml --write-config
 **若 verification 报缺表（discover 尚未完成）：**
 
 ```bash
-openbkn vega catalog discover <catalog_id> --wait
+openbkn --json vega catalog discover <catalog_id>
+# 记下返回的 task id，再查询：openbkn --json vega discover-task get <task_id>
 python3 setup_catalog.py --config config.yaml --write-config
 ```
 
@@ -612,7 +613,7 @@ python3 smoke_test.py --config config.yaml
 | 灌库报 Unknown database | 目标库未创建 | 先建空库，库名与 `database` 字段一致 |
 | 误指向共用库 | `recreate` 覆盖同名 12 表 | 改用专用库名；勿对生产库执行灌库 |
 | 创建 Catalog 报 Connector initialization failed / config is incomplete | 连接器 JSON 缺 `password` 或 PG 用户未设密码 | 见步骤 4「密码设置」；填 `database.password` 后重跑 `setup_catalog.py` |
-| 扫描后 verification 缺表 | discover 尚未完成 | `openbkn vega catalog discover <catalog_id> --wait` 后再跑脚本 |
+| 扫描后 verification 缺表 | discover 尚未完成 | 运行 `python3 setup_catalog.py --config config.yaml --write-config`；脚本会轮询 discovery task 后再校验 |
 | Catalog 扫描不到表 | 数据源未 enable、库名 / schema 不对 | 确认 Catalog 连接与步骤 3 同一库名；重新 discover |
 | MySQL 下 schema 无效 | MySQL 无 PostgreSQL 式 schema；`database.schema` 会被忽略 | 配置中 `schema` 可留空或忽略；Catalog 绑定库名即可，勿填 `database.public` 形式 |
 | 绑定后 query 为空 | 表名与映射不一致、PK 未配置 | 核对附录 B；必要时走 UI 手绑 |

--- a/samples/supply_ontology_hand/tools/bind_action_datasets.py
+++ b/samples/supply_ontology_hand/tools/bind_action_datasets.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 import subprocess
 import tempfile
+import time
 import yaml
+
+
+_DISCOVERY_SUCCESS = {"completed"}
+_DISCOVERY_FAILURE = {"failed", "cancelled", "stopped"}
 
 
 def build_bindings(mapping: dict, *, kn_id: str, schema: str) -> list[dict]:
@@ -50,8 +55,26 @@ def find_resource_id(catalog_id: str, dataset: str, run_cmd=run_cmd) -> str:
     raise RuntimeError(f"resource not found for Action Dataset {dataset}")
 
 
-def discover_catalog(catalog_id: str, run_cmd=run_cmd) -> None:
-    run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id, "--wait"])
+def discover_catalog(catalog_id: str, run_cmd=run_cmd, *, timeout_seconds: float = 120) -> None:
+    created = parse_json(run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id]))
+    task_id = created.get("id") if isinstance(created, dict) else None
+    if not isinstance(task_id, str) or not task_id:
+        raise RuntimeError(f"catalog discover returned no task id: {created!r}")
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        task = parse_json(run_cmd(["openbkn", "--json", "vega", "discover-task", "get", task_id]))
+        if not isinstance(task, dict):
+            raise RuntimeError(f"discover task {task_id} returned unexpected payload: {task!r}")
+        status = str(task.get("status", "")).lower()
+        if status in _DISCOVERY_SUCCESS:
+            return
+        if status in _DISCOVERY_FAILURE:
+            message = task.get("message")
+            raise RuntimeError(f"discover task {task_id} {status}{': ' + str(message) if message else ''}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"discover task {task_id} did not complete within {timeout_seconds:g} seconds")
+        time.sleep(2)
 
 
 def resolve_path(root: Path, value: str) -> Path:

--- a/samples/supply_ontology_hand/tools/setup_catalog.py
+++ b/samples/supply_ontology_hand/tools/setup_catalog.py
@@ -7,6 +7,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -17,6 +18,8 @@ from bind_kn_resources import parse_cli_json
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _DEFAULT_MAP = _SCRIPT_DIR / "mapping" / "object_table_map.yaml"
 _UI_FALLBACK_MSG = "请按说明书步骤 4 UI 挂接扫描"
+_DISCOVERY_SUCCESS = {"completed"}
+_DISCOVERY_FAILURE = {"failed", "cancelled", "stopped"}
 
 
 def run_cmd(args: list[str]) -> str:
@@ -81,6 +84,48 @@ def _find_catalog_by_name(name: str, *, run_cmd: Callable[[list[str]], str]) -> 
         if entry.get("name") == name:
             return entry
     return None
+
+
+def _single_catalog(payload: object, catalog_id: str) -> dict:
+    if isinstance(payload, dict) and isinstance(payload.get("entries"), list):
+        entries = payload["entries"]
+        if len(entries) == 1 and isinstance(entries[0], dict):
+            return entries[0]
+    if isinstance(payload, dict):
+        return payload
+    raise RuntimeError(f"catalog get returned unexpected payload for {catalog_id}: {payload!r}")
+
+
+def wait_for_discovery(
+    catalog_id: str,
+    *,
+    run_cmd: Callable[[list[str]], str],
+    timeout_seconds: float = 120,
+    poll_interval_seconds: float = 2,
+) -> dict:
+    created = parse_cli_json(
+        run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id])
+    )
+    task_id = created.get("id") if isinstance(created, dict) else None
+    if not isinstance(task_id, str) or not task_id:
+        raise RuntimeError(f"catalog discover returned no task id: {created!r}")
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        task = parse_cli_json(
+            run_cmd(["openbkn", "--json", "vega", "discover-task", "get", task_id])
+        )
+        if not isinstance(task, dict):
+            raise RuntimeError(f"discover task {task_id} returned unexpected payload: {task!r}")
+        status = str(task.get("status", "")).lower()
+        if status in _DISCOVERY_SUCCESS:
+            return task
+        if status in _DISCOVERY_FAILURE:
+            message = task.get("message")
+            raise RuntimeError(f"discover task {task_id} {status}{': ' + str(message) if message else ''}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"discover task {task_id} did not complete within {timeout_seconds:g} seconds")
+        time.sleep(poll_interval_seconds)
 
 
 def _catalog_resources(catalog_id: str, *, run_cmd: Callable[[list[str]], str]) -> list[dict]:
@@ -175,11 +220,10 @@ def run_catalog_setup(
     catalog_id = (vega.get("catalog_id") or "").strip()
     catalog_entry: dict | None = None
     if catalog_id:
-        catalog_entry = parse_cli_json(
-            cmd(["openbkn", "--json", "vega", "catalog", "get", catalog_id])
+        catalog_entry = _single_catalog(
+            parse_cli_json(cmd(["openbkn", "--json", "vega", "catalog", "get", catalog_id])),
+            catalog_id,
         )
-        if not isinstance(catalog_entry, dict):
-            raise RuntimeError(f"catalog get returned unexpected payload for {catalog_id}")
         report["steps"].append({"action": "reuse_config_catalog_id", "catalog_id": catalog_id})
     else:
         catalog_entry = _find_catalog_by_name(catalog_name, run_cmd=cmd)
@@ -227,9 +271,8 @@ def run_catalog_setup(
     report["steps"].append({"action": "test_connection"})
 
     if not skip_discover:
-        discover_args = ["openbkn", "--json", "vega", "catalog", "discover", catalog_id, "--wait"]
-        parse_cli_json(cmd(discover_args))
-        report["steps"].append({"action": "discover", "wait": True})
+        task = wait_for_discovery(catalog_id, run_cmd=cmd)
+        report["steps"].append({"action": "discover", "task_id": task.get("id")})
     else:
         report["steps"].append({"action": "discover_skipped"})
 

--- a/samples/supply_ontology_hand/tools/tests/test_bind_action_datasets.py
+++ b/samples/supply_ontology_hand/tools/tests/test_bind_action_datasets.py
@@ -23,8 +23,20 @@ def test_build_bindings_expands_schema_placeholder():
 
 def test_discover_catalog_waits_for_new_action_tables():
     calls = []
-    discover_catalog("catalog1", run_cmd=lambda args: calls.append(args) or "{}")
-    assert calls == [["openbkn", "--json", "vega", "catalog", "discover", "catalog1", "--wait"]]
+
+    def run_cmd(args):
+        calls.append(args)
+        if args[2:5] == ["vega", "catalog", "discover"]:
+            return '{"id":"task-1"}'
+        if args[2:5] == ["vega", "discover-task", "get"]:
+            return '{"id":"task-1","status":"completed"}'
+        raise AssertionError(f"unexpected command: {args}")
+
+    discover_catalog("catalog1", run_cmd=run_cmd)
+    assert calls == [
+        ["openbkn", "--json", "vega", "catalog", "discover", "catalog1"],
+        ["openbkn", "--json", "vega", "discover-task", "get", "task-1"],
+    ]
 
 
 def test_dry_run_does_not_update_object_type():

--- a/samples/supply_ontology_hand/tools/tests/test_setup_catalog.py
+++ b/samples/supply_ontology_hand/tools/tests/test_setup_catalog.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from setup_catalog import (
+    _single_catalog,
     build_connector_config,
     expected_tables,
     run_catalog_setup,
@@ -16,6 +17,13 @@ from setup_catalog import (
 )
 
 MAP = Path(__file__).resolve().parents[1] / "mapping" / "object_table_map.yaml"
+
+
+def test_catalog_get_unwraps_current_entries_envelope():
+    assert _single_catalog({"entries": [{"id": "cat-1", "enabled": True}]}, "cat-1") == {
+        "id": "cat-1",
+        "enabled": True,
+    }
 
 
 def test_build_connector_config_uses_catalog_host_override():
@@ -93,7 +101,9 @@ def test_run_catalog_setup_create_enable_discover():
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "test-connection"]:
             return json.dumps({"ok": True})
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "discover"]:
-            return json.dumps({"status": "completed"})
+            return json.dumps({"id": "task-1"})
+        if args[:5] == ["openbkn", "--json", "vega", "discover-task", "get"]:
+            return json.dumps({"id": "task-1", "status": "completed"})
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "resources"]:
             import yaml
 

--- a/samples/supply_ontology_hand_en/docs/agent-operation-guide.md
+++ b/samples/supply_ontology_hand_en/docs/agent-operation-guide.md
@@ -30,7 +30,7 @@ python3 tools/import_kn.py --json kn/supply_ontology_hand_en.json --resolve-embe
 python3 tools/bind_kn_resources.py --config tools/config.poc.yaml --kn-id supply_ontology_hand_en --table-prefix hand_
 python3 tools/register_skills.py --dry-run
 python3 tools/setup_skill_dataset.py --interactive --apply --kn-id supply_ontology_hand_en
-openbkn --json vega catalog discover <catalog-id> --wait
+python3 tools/setup_catalog.py --config tools/config.yaml --write-config
 python3 tools/bind_skill_dataset.py --kn-id supply_ontology_hand_en --catalog-id <catalog-id> --apply
 python3 tools/bootstrap_action_layer.py \
   --config tools/config.poc.yaml \

--- a/samples/supply_ontology_hand_en/docs/openbkn-hand-import-guide.md
+++ b/samples/supply_ontology_hand_en/docs/openbkn-hand-import-guide.md
@@ -426,7 +426,7 @@ Full mapping: `tools/mapping/object_table_map.yaml`.
 | Import name exists | KN name collision | Remove conflict or UI import |
 | Load connection failed | DB missing / wrong creds | `CREATE DATABASE`; check `config.yaml` |
 | Catalog incomplete connector | Missing `password` | Set PG password; fill `database.password` |
-| Discover missing tables | Scan not finished | `vega catalog discover <id> --wait` |
+| Discover missing tables | Scan not finished | Run `python3 tools/setup_catalog.py --config tools/config.yaml --write-config`; it polls the discovery task before verifying tables. |
 | Query empty after bind | Wrong table/PK | Check Appendix B; UI re-bind |
 | Script bind failed | CLI version / permissions | Step 5 UI fallback |
 

--- a/samples/supply_ontology_hand_en/docs/openbkn-hand-import-guide_cn.md
+++ b/samples/supply_ontology_hand_en/docs/openbkn-hand-import-guide_cn.md
@@ -369,7 +369,7 @@ python3 setup_catalog.py --config config.yaml --write-config
 
 1. 按 `database` + `vega.catalog_host` 组装连接器配置  
 2. 若 `catalog_id` 为空：按 `catalog_name` 查找已有 Catalog，否则 `vega catalog create`  
-3. `vega catalog enable` → `test-connection` → `discover --wait`  
+3. `vega catalog enable` → `test-connection` → 触发异步 `discover` 并轮询任务终态
 4. 校验 Catalog 中可见附录 A 的 **12 张表**  
 5. `--write-config` 时将 `catalog_id` 写回 `config.yaml`
 
@@ -381,7 +381,8 @@ python3 setup_catalog.py --config config.yaml --write-config
 **若 verification 报缺表（discover 尚未完成）：**
 
 ```bash
-openbkn vega catalog discover <catalog_id> --wait
+openbkn --json vega catalog discover <catalog_id>
+# 记下返回的 task id，再查询：openbkn --json vega discover-task get <task_id>
 python3 setup_catalog.py --config config.yaml --write-config
 ```
 
@@ -612,7 +613,7 @@ python3 smoke_test.py --config config.yaml
 | 灌库报 Unknown database | 目标库未创建 | 先建空库，库名与 `database` 字段一致 |
 | 误指向共用库 | `recreate` 覆盖同名 12 表 | 改用专用库名；勿对生产库执行灌库 |
 | 创建 Catalog 报 Connector initialization failed / config is incomplete | 连接器 JSON 缺 `password` 或 PG 用户未设密码 | 见步骤 4「密码设置」；填 `database.password` 后重跑 `setup_catalog.py` |
-| 扫描后 verification 缺表 | discover 尚未完成 | `openbkn vega catalog discover <catalog_id> --wait` 后再跑脚本 |
+| 扫描后 verification 缺表 | discover 尚未完成 | 运行 `python3 setup_catalog.py --config config.yaml --write-config`；脚本会轮询 discovery task 后再校验 |
 | Catalog 扫描不到表 | 数据源未 enable、库名 / schema 不对 | 确认 Catalog 连接与步骤 3 同一库名；重新 discover |
 | MySQL 下 schema 无效 | MySQL 无 PostgreSQL 式 schema；`database.schema` 会被忽略 | 配置中 `schema` 可留空或忽略；Catalog 绑定库名即可，勿填 `database.public` 形式 |
 | 绑定后 query 为空 | 表名与映射不一致、PK 未配置 | 核对附录 B；必要时走 UI 手绑 |

--- a/samples/supply_ontology_hand_en/tools/bind_action_datasets.py
+++ b/samples/supply_ontology_hand_en/tools/bind_action_datasets.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 import subprocess
 import tempfile
+import time
 import yaml
+
+
+_DISCOVERY_SUCCESS = {"completed"}
+_DISCOVERY_FAILURE = {"failed", "cancelled", "stopped"}
 
 
 def build_bindings(mapping: dict, *, kn_id: str, schema: str) -> list[dict]:
@@ -47,8 +52,26 @@ def find_resource_id(catalog_id, dataset, run_cmd=run_cmd):
     raise RuntimeError(f"resource not found for Action Dataset {dataset}")
 
 
-def discover_catalog(catalog_id, run_cmd=run_cmd):
-    run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id, "--wait"])
+def discover_catalog(catalog_id, run_cmd=run_cmd, *, timeout_seconds=120):
+    created = parse_json(run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id]))
+    task_id = created.get("id") if isinstance(created, dict) else None
+    if not isinstance(task_id, str) or not task_id:
+        raise RuntimeError(f"catalog discover returned no task id: {created!r}")
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        task = parse_json(run_cmd(["openbkn", "--json", "vega", "discover-task", "get", task_id]))
+        if not isinstance(task, dict):
+            raise RuntimeError(f"discover task {task_id} returned unexpected payload: {task!r}")
+        status = str(task.get("status", "")).lower()
+        if status in _DISCOVERY_SUCCESS:
+            return
+        if status in _DISCOVERY_FAILURE:
+            message = task.get("message")
+            raise RuntimeError(f"discover task {task_id} {status}{': ' + str(message) if message else ''}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"discover task {task_id} did not complete within {timeout_seconds:g} seconds")
+        time.sleep(2)
 
 
 def resolve_path(root, value):

--- a/samples/supply_ontology_hand_en/tools/setup_catalog.py
+++ b/samples/supply_ontology_hand_en/tools/setup_catalog.py
@@ -7,6 +7,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -17,6 +18,8 @@ from bind_kn_resources import parse_cli_json
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _DEFAULT_MAP = _SCRIPT_DIR / "mapping" / "object_table_map.yaml"
 _UI_FALLBACK_MSG = "请按说明书步骤 4 UI 挂接扫描"
+_DISCOVERY_SUCCESS = {"completed"}
+_DISCOVERY_FAILURE = {"failed", "cancelled", "stopped"}
 
 
 def run_cmd(args: list[str]) -> str:
@@ -81,6 +84,48 @@ def _find_catalog_by_name(name: str, *, run_cmd: Callable[[list[str]], str]) -> 
         if entry.get("name") == name:
             return entry
     return None
+
+
+def _single_catalog(payload: object, catalog_id: str) -> dict:
+    if isinstance(payload, dict) and isinstance(payload.get("entries"), list):
+        entries = payload["entries"]
+        if len(entries) == 1 and isinstance(entries[0], dict):
+            return entries[0]
+    if isinstance(payload, dict):
+        return payload
+    raise RuntimeError(f"catalog get returned unexpected payload for {catalog_id}: {payload!r}")
+
+
+def wait_for_discovery(
+    catalog_id: str,
+    *,
+    run_cmd: Callable[[list[str]], str],
+    timeout_seconds: float = 120,
+    poll_interval_seconds: float = 2,
+) -> dict:
+    created = parse_cli_json(
+        run_cmd(["openbkn", "--json", "vega", "catalog", "discover", catalog_id])
+    )
+    task_id = created.get("id") if isinstance(created, dict) else None
+    if not isinstance(task_id, str) or not task_id:
+        raise RuntimeError(f"catalog discover returned no task id: {created!r}")
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        task = parse_cli_json(
+            run_cmd(["openbkn", "--json", "vega", "discover-task", "get", task_id])
+        )
+        if not isinstance(task, dict):
+            raise RuntimeError(f"discover task {task_id} returned unexpected payload: {task!r}")
+        status = str(task.get("status", "")).lower()
+        if status in _DISCOVERY_SUCCESS:
+            return task
+        if status in _DISCOVERY_FAILURE:
+            message = task.get("message")
+            raise RuntimeError(f"discover task {task_id} {status}{': ' + str(message) if message else ''}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"discover task {task_id} did not complete within {timeout_seconds:g} seconds")
+        time.sleep(poll_interval_seconds)
 
 
 def _catalog_resources(catalog_id: str, *, run_cmd: Callable[[list[str]], str]) -> list[dict]:
@@ -175,11 +220,10 @@ def run_catalog_setup(
     catalog_id = (vega.get("catalog_id") or "").strip()
     catalog_entry: dict | None = None
     if catalog_id:
-        catalog_entry = parse_cli_json(
-            cmd(["openbkn", "--json", "vega", "catalog", "get", catalog_id])
+        catalog_entry = _single_catalog(
+            parse_cli_json(cmd(["openbkn", "--json", "vega", "catalog", "get", catalog_id])),
+            catalog_id,
         )
-        if not isinstance(catalog_entry, dict):
-            raise RuntimeError(f"catalog get returned unexpected payload for {catalog_id}")
         report["steps"].append({"action": "reuse_config_catalog_id", "catalog_id": catalog_id})
     else:
         catalog_entry = _find_catalog_by_name(catalog_name, run_cmd=cmd)
@@ -227,9 +271,8 @@ def run_catalog_setup(
     report["steps"].append({"action": "test_connection"})
 
     if not skip_discover:
-        discover_args = ["openbkn", "--json", "vega", "catalog", "discover", catalog_id, "--wait"]
-        parse_cli_json(cmd(discover_args))
-        report["steps"].append({"action": "discover", "wait": True})
+        task = wait_for_discovery(catalog_id, run_cmd=cmd)
+        report["steps"].append({"action": "discover", "task_id": task.get("id")})
     else:
         report["steps"].append({"action": "discover_skipped"})
 

--- a/samples/supply_ontology_hand_en/tools/tests/test_bind_action_datasets.py
+++ b/samples/supply_ontology_hand_en/tools/tests/test_bind_action_datasets.py
@@ -15,8 +15,20 @@ def test_build_bindings_expands_schema_placeholder():
 
 def test_discover_catalog_waits_for_new_action_tables():
     calls = []
-    discover_catalog("catalog1", run_cmd=lambda args: calls.append(args) or "{}")
-    assert calls == [["openbkn", "--json", "vega", "catalog", "discover", "catalog1", "--wait"]]
+
+    def run_cmd(args):
+        calls.append(args)
+        if args[2:5] == ["vega", "catalog", "discover"]:
+            return '{"id":"task-1"}'
+        if args[2:5] == ["vega", "discover-task", "get"]:
+            return '{"id":"task-1","status":"completed"}'
+        raise AssertionError(f"unexpected command: {args}")
+
+    discover_catalog("catalog1", run_cmd=run_cmd)
+    assert calls == [
+        ["openbkn", "--json", "vega", "catalog", "discover", "catalog1"],
+        ["openbkn", "--json", "vega", "discover-task", "get", "task-1"],
+    ]
 
 
 def test_dry_run_does_not_update_object_type():

--- a/samples/supply_ontology_hand_en/tools/tests/test_setup_catalog.py
+++ b/samples/supply_ontology_hand_en/tools/tests/test_setup_catalog.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from setup_catalog import (
+    _single_catalog,
     build_connector_config,
     expected_tables,
     run_catalog_setup,
@@ -16,6 +17,13 @@ from setup_catalog import (
 )
 
 MAP = Path(__file__).resolve().parents[1] / "mapping" / "object_table_map.yaml"
+
+
+def test_catalog_get_unwraps_current_entries_envelope():
+    assert _single_catalog({"entries": [{"id": "cat-1", "enabled": True}]}, "cat-1") == {
+        "id": "cat-1",
+        "enabled": True,
+    }
 
 
 def test_build_connector_config_uses_catalog_host_override():
@@ -93,7 +101,9 @@ def test_run_catalog_setup_create_enable_discover():
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "test-connection"]:
             return json.dumps({"ok": True})
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "discover"]:
-            return json.dumps({"status": "completed"})
+            return json.dumps({"id": "task-1"})
+        if args[:5] == ["openbkn", "--json", "vega", "discover-task", "get"]:
+            return json.dumps({"id": "task-1", "status": "completed"})
         if args[:5] == ["openbkn", "--json", "vega", "catalog", "resources"]:
             import yaml
 

--- a/samples/world-cup/README.md
+++ b/samples/world-cup/README.md
@@ -13,7 +13,7 @@
                        │                     (pre-creates wc_matches / wc_team_appearances
                        │                      with VARCHAR(255) to dodge MySQL Error 1118)
                        │
-                       ├─ 3) Vega scan       vega catalog create + discover --wait
+                       ├─ 3) Vega scan       vega catalog create + asynchronous discover
                        │
    ./run.sh  ─────────►├─ 4) Render BKN      map vega Resources → render worldcup-bkn.tar
                        │
@@ -49,9 +49,7 @@ Keep attribution and the share-alike notice on derived data. **Pin a revision** 
 2. **Authenticate the CLI**: `openbkn auth login https://<your-platform-url>` (writes `~/.bkn/`).
 3. **Register an embedding model** (the vector index needs it; the full-text index builds without it):
    ```bash
-   openbkn model small add --name text-embedding-v4-cn \
-     --type embedding --batch-size 10 --max-tokens 512 --embedding-dim 1024 \
-     --model-config-file <emb.json>
+   openbkn model small add --body-file <emb.json>
    ```
    `EMBEDDING_MODEL_NAME` in `.env` (default `text-embedding-v4-cn`) is passed to the build
    by **name** — Vega resolves embedding models by name and rejects a raw model id.
@@ -111,12 +109,11 @@ Once `./run.sh` finishes, run the published `vega_sql_execute` tool. Resolve a t
 
 ```bash
 # list table resources to grab a resource_id
-openbkn vega resource list --datasource-id <catalog_id> --type table
+openbkn vega resource list --catalog-id <catalog_id> --category table
 
 # run SQL through the published tool (TOOLBOX_BOX_ID / VEGA_TOOL_ID are echoed by step 6)
-openbkn tool invoke <VEGA_TOOL_ID> --toolbox <TOOLBOX_BOX_ID> \
-  --input query='<your SQL with {{<resource_id>}} placeholders>' \
-  --input query_format=sql
+openbkn tool execute <VEGA_TOOL_ID> --toolbox <TOOLBOX_BOX_ID> \
+  --body '{"query":"<your SQL with {{<resource_id>}} placeholders>","query_format":"sql"}'
 ```
 
 ### Q1 · Messi's World Cup awards

--- a/samples/world-cup/README_cn.md
+++ b/samples/world-cup/README_cn.md
@@ -13,7 +13,7 @@
                        │                 （预建 wc_matches / wc_team_appearances 为 VARCHAR(255)
                        │                   规避 MySQL Error 1118 行宽超限）
                        │
-                       ├─ 3) Vega 扫描    vega catalog create + discover --wait
+                       ├─ 3) Vega 扫描    vega catalog create + 异步 discover
                        │
    ./run.sh  ─────────►├─ 4) 渲染 BKN     map vega Resources → render worldcup-bkn.tar
                        │
@@ -53,9 +53,7 @@ CSV 来自 Joshua C. Fjelstul 的 **The Fjelstul World Cup Database**（[仓库]
 2. **CLI 登录**：`openbkn auth login https://<你的平台地址>`（凭据写入 `~/.bkn/`）。
 3. **注册 embedding 模型**（向量索引需要；不注册会自动降级为关键字索引）：
    ```bash
-   openbkn model small add --name text-embedding-v4-cn \
-     --type embedding --batch-size 10 --max-tokens 512 --embedding-dim 1024 \
-     --model-config-file <emb.json>
+   openbkn model small add --body-file <emb.json>
    ```
    `.env` 里的 `EMBEDDING_MODEL_NAME` 运行时被解析成 `model_id`（默认 `text-embedding-v4-cn`）。
 4. **把 BKN 默认 embedding 写进 ConfigMap**（KN 级语义检索路径用到；本示例不强依赖）：
@@ -114,12 +112,11 @@ step 6 会发布一个 OpenAPI 描述的工具 `vega_sql_execute`，对 `worldcu
 
 ```bash
 # 列出表 resource，拿 resource_id
-openbkn vega resource list --datasource-id <catalog_id> --type table
+openbkn vega resource list --catalog-id <catalog_id> --category table
 
 # 通过已发布的工具跑 SQL（TOOLBOX_BOX_ID / VEGA_TOOL_ID 由 step 6 打印出来）
-openbkn tool invoke <VEGA_TOOL_ID> --toolbox <TOOLBOX_BOX_ID> \
-  --input query='<带 {{<resource_id>}} 占位的 SQL>' \
-  --input query_format=sql
+openbkn tool execute <VEGA_TOOL_ID> --toolbox <TOOLBOX_BOX_ID> \
+  --body '{"query":"<带 {{<resource_id>}} 占位的 SQL>","query_format":"sql"}'
 ```
 
 ### Q1 · 梅西在世界杯获过哪些奖

--- a/samples/world-cup/run.sh
+++ b/samples/world-cup/run.sh
@@ -458,7 +458,7 @@ step_3_vega_scan() {
     # Auto-skip discover if catalog already has all 27 table resources.
     if [ "${FORCE_DISCOVER:-0}" != 1 ]; then
         local n_resources
-        n_resources="$("${KWEAV[@]}" vega resource list --datasource-id "$catalog_id" --type table --limit 50 2>/dev/null \
+        n_resources="$("${KWEAV[@]}" vega resource list --catalog-id "$catalog_id" --category table --limit 50 2>/dev/null \
             | _extract_cli_json | jq '.entries | length' 2>/dev/null || echo 0)"
         if [ "${n_resources:-0}" -ge 27 ]; then
             echo "  skip discover — $n_resources table resources already present (FORCE_DISCOVER=1 to redo)" >&2
@@ -468,12 +468,12 @@ step_3_vega_scan() {
         fi
     fi
 
-    echo "  Running discover --wait …" >&2
-    "${KWEAV[@]}" call "/api/vega-backend/v1/catalogs/${catalog_id}/discover?wait=true" -X POST >/dev/null 2>&1 || true
+    echo "  Starting catalog discovery …" >&2
+    "${KWEAV[@]}" vega catalog discover "$catalog_id" >/dev/null
     # Discovery is asynchronous — poll until table resources appear (~90s max).
     local _n=0
     for _i in $(seq 1 30); do
-        _n="$("${KWEAV[@]}" vega resource list --datasource-id "$catalog_id" --type table --limit 50 2>/dev/null \
+        _n="$("${KWEAV[@]}" vega resource list --catalog-id "$catalog_id" --category table --limit 50 2>/dev/null \
             | _extract_cli_json | jq '.entries | length' 2>/dev/null || echo 0)"
         [ "${_n:-0}" -ge 27 ] && break
         sleep 3
@@ -521,7 +521,7 @@ step_4_render_bkn() {
     # Note: 0.8.0 dropped /catalogs/:id/resources nested endpoint in favor of the
     # top-level /resources?catalog_id=... filter. `vega resource list --catalog-id`
     # SDK call hits the new path on both 0.7.0 and 0.8.0.
-    raw="$("${KWEAV[@]}" vega resource list --datasource-id "$catalog_id" --type table --limit 500 2>&1)"
+    raw="$("${KWEAV[@]}" vega resource list --catalog-id "$catalog_id" --category table --limit 500 2>&1)"
     body="$(printf '%s' "$raw" | _extract_cli_json)" || { echo "Error parsing vega catalog resources output." >&2; exit 1; }
     nres="$(printf '%s' "$body" | jq '.entries | length')"
     echo "  table resources returned: $nres" >&2
@@ -871,10 +871,9 @@ step_6_toolbox() {
     echo "  Done. Vega catalog BKN '${kn_id:-worldcup_vega_catalog_bkn}' is live with a published" >&2
     echo "  vega_sql_execute tool (TOOLBOX_BOX_ID=$box_id  VEGA_TOOL_ID=$tool_id) over the 27 wc_* tables." >&2
     echo "  Query the resources directly, e.g.:" >&2
-    echo "    ${KWEAV[*]} tool invoke $tool_id --toolbox $box_id \\" >&2
-    echo "      --input query='SELECT tournament_name, winner FROM {{<tournaments_resource_id>}} ORDER BY year DESC LIMIT 5' \\" >&2
-    echo "      --input query_format=sql" >&2
-    echo "  (resource_id comes from: ${KWEAV[*]} vega resource list --datasource-id <catalog> --type table)" >&2
+    echo "    ${KWEAV[*]} tool execute $tool_id --toolbox $box_id \\" >&2
+    echo "      --body '{\"query\":\"SELECT tournament_name, winner FROM {{<tournaments_resource_id>}} ORDER BY year DESC LIMIT 5\",\"query_format\":\"sql\"}'" >&2
+    echo "  (resource_id comes from: ${KWEAV[*]} vega resource list --catalog-id <catalog> --category table)" >&2
 }
 
 # ─── Driver ─────────────────────────────────────────────────────────────────

--- a/samples/world-cup/scripts/render_worldcup_bkn_vega_placeholders.py
+++ b/samples/world-cup/scripts/render_worldcup_bkn_vega_placeholders.py
@@ -8,7 +8,7 @@ Input: JSON object mapping placeholder name → uuid, e.g.:
 Paths default to sibling dirs under samples/world-cup/.
 
 Example:
-  openbkn --json vega resource list --datasource-id <cid> --type table --limit 500 \\
+  openbkn --json vega resource list --catalog-id <cid> --category table --limit 500 \\
     | python3 scripts/map_vega_table_resources.py > mappings.json
   python3 scripts/render_worldcup_bkn_vega_placeholders.py --mapping mappings.json \\
     --src worldcup-bkn --dst .rendered-bkn-vega


### PR DESCRIPTION
## Summary
- poll asynchronous Vega discovery tasks in catalog setup and action-dataset binding scripts
- replace obsolete Vega, tool, and model CLI arguments in world-cup samples
- update mirrored Chinese and English sample documentation and regression tests

## Validation
- `PYTHONPATH=. python3 -m pytest tests/test_setup_catalog.py tests/test_bind_action_datasets.py` (both supply-ontology sample directories)
- `python3 -m py_compile setup_catalog.py bind_action_datasets.py` (both supply-ontology sample directories)
- `bash -n samples/world-cup/run.sh`
- `git diff --check`